### PR TITLE
Expand for DoQ and DoT

### DIFF
--- a/draft-lenders-dns-over-coap.md
+++ b/draft-lenders-dns-over-coap.md
@@ -70,6 +70,10 @@ proxies, which provide an additional level of caching; re-use of data
 structures for application traffic and DNS information, which saves memory
 on constrained devices.
 
+To prevent resource requirements of DTLS or TLS on top of UDP (e.g.,
+introduced by DNS over QUIC {{?I-D.ietf-dprive-dnsoquic}}), DoC allows
+for lightweight end-to-end payload encryption based on OSCORE.
+
 ~~~ drawing
 
                 - FETCH coaps://[2001:db8::1]/


### PR DESCRIPTION
During the CoRE interim it was argued that we need to stronger distinguish DoC from the other DNS-over-X approaches. For the most part, this was already done (DoH, DoT, and DNS-over-DTLS). This adds a few sentences on DNS over QUIC (DoQ), mostly arguing on similar size requirement problems as we do for DoH/DoT.