### PR TITLE
Add note on ETag and response codes

### DIFF
--- a/draft-lenders-dns-over-coap.md
+++ b/draft-lenders-dns-over-coap.md
@@ -290,8 +290,8 @@ With long-lived responses, the client does not need to revalidate often.
 With responses large enough to be fragmented,
 it's best practice for servers to set an ETag anyway.
 As specified in {{!RFC7252}} and {{!RFC8132}}, if the response associated with
-the ETag is still valid, the response MUST use the "2.03 Valid" code and MUST
-NOT carry any payload.
+the ETag is still valid, the response uses the "2.03 Valid" code and consequently
+carries no payload.
 
 ### Examples
 


### PR DESCRIPTION
While reading up on ETags again, I noticed, that our statements on response codes in 4.3.1 might cause confusion, when it comes to the ETag options in responses:

> It is RECOMMENDED that CoAP responses that carry any valid DNS response use a "2.xx Success" response code. A response to a GET or FETCH request SHOULD use the "2.05 Content" code. A response to a POST request SHOULD use the "2.01 Created" code.

or

> It is RECOMMENDED that CoAP responses that carry any valid DNS response use a "2.05 Content" response code.

in https://github.com/anr-bmbf-pivot/draft-dns-over-coap/pull/8 respectively.

This serves as a reminder, that in accordance with RFCs 7252 and 8132, servers that respond to a requested ETag that is valid, MUST use the "2.03 Valid" response code and that the response MUST NOT carry any payload.