### PR TITLE
Don't call OSCORE "end-to-end encrypted"

### DIFF
--- a/draft-ietf-core-dns-over-coap.md
+++ b/draft-ietf-core-dns-over-coap.md
@@ -105,7 +105,7 @@ on constrained devices.
 
 To prevent resource requirements of DTLS or TLS on top of UDP (e.g.,
 introduced by DNS over QUIC {{-doq}}), DoC allows
-for lightweight end-to-end payload encryption based on OSCORE.
+for lightweight payload encryption based on OSCORE.
 
 ~~~ aasvg
 
@@ -336,7 +336,7 @@ resource record as well.
 
 OSCORE
 ------
-It is RECOMMENDED to carry DNS messages end-to-end encrypted using OSCORE {{-oscore}}.
+It is RECOMMENDED to carry DNS messages encrypted using OSCORE {{-oscore}} between the DoC client and the DoC server.
 The exchange of the security context is out of scope of this document.
 
 Mapping DoC to DoH


### PR DESCRIPTION
It is end-to-end from a CoAP perspective (and thus an improvement over DTLS's hop-by-hop), but not end-to-end from DNS's perspective (where DNSSEC would give at least end-to-end integrity protection).

This addresses a comment from Ben Schwarz in [1]:

> BTW, this reminds me that referring to OSCORE as “end-to-end” in this
> context is confusing, since the logical “endpoints” are the stub
> resolver and the authoritative nameserver.

[1]: https://mailarchive.ietf.org/arch/msg/core/ysQNv7C2UyQJglOE5K6IqzHi1Ug