### PR TITLE
nit: paths keep the CoAP options (and thus message) small

### DIFF
--- a/draft-ietf-core-dns-over-coap.md
+++ b/draft-ietf-core-dns-over-coap.md
@@ -179,7 +179,7 @@ When discovering the DNS resource through a link mechanism that allows describin
 used to identify a generic DNS resolver that is available to the client.
 
 While there is no path specified it is RECOMMENDED to use the root path "/" for the DNS resource to
-keep the CoAP header small.
+keep the CoAP requests small.
 
 Basic Message Exchange
 ======================


### PR DESCRIPTION
(Branch was called small-fixes, actually it's just one for the latest changes)

The CoAP header in CoAP-over-UDP are the bytes that contain code, type and MID, which are of constant size.