### PR TITLE
Update corr-clar reference

### DIFF
--- a/draft-ietf-core-dns-over-coap.md
+++ b/draft-ietf-core-dns-over-coap.md
@@ -77,16 +77,7 @@ informative:
   I-D.lenders-core-dnr: core-dnr
   I-D.amsuess-core-cachable-oscore: cachable-oscore
   DoC-paper: DOI.10.1145/3609423
-  amp-0rtt:
-   title: 'PR #40 "Amplification and 0-RTT" on "CoAP: Corrections and Clarifications"'
-   date: 2024-09-25
-   format:
-     HTML: https://github.com/core-wg/corrclar/pull/40
-   ann: |
-     Note: It is expected that that PR will be merged way ahead of this document's publication;
-     at the next revision, this reference will be replaced with a reference to what will by then most likely be
-     I-D.ietf-core-corr-clar-00 (now bormann-core-clar-05).
-
+  I-D.ietf-core-corr-clar: core-corrclar
 --- abstract
 
 This document defines a protocol for sending DNS messages over the
@@ -499,7 +490,7 @@ Security Considerations
 General CoAP security considerations apply.
 Exceeding those in {{Section 11 of RFC7252}},
 the request patterns of DoC make it likely that long-lived security contexts are maintained:
-{{amp-0rtt}} goes into more detail on what needs to be done
+{{Section 2.6 of -core-corrclar}} goes into more detail on what needs to be done
 when those are resumed from a new endpoint.
 
 When using unencrypted CoAP (see {{sec:unencrypted-coap}}), setting the ID of a DNS message to 0 as


### PR DESCRIPTION
Updates the reference to https://github.com/core-wg/corrclar/pull/40 to [Section 2.6 of -core-corr-clar](https://datatracker.ietf.org/doc/html/draft-ietf-core-corr-clar#section-2.6) as it now got merged.