### PR TITLE
Update push notifications

### DIFF
--- a/draft-ietf-core-dns-over-coap.md
+++ b/draft-ietf-core-dns-over-coap.md
@@ -568,7 +568,7 @@ Whenever the DoC server receives a DNS Push message from the DNS
 infrastructure for an observed resource record, the DoC server sends an appropriate Observe notification response
 to the DoC client.
 
-A server that cannot proxy to DNS Push (or any other means of obtaining new records) SHOULD NOT send the response as a notification
+A server that cannot proxy to DNS Push (or any other means of obtaining new records) should not send the response as a notification
 (i.e., it should not send the Observe option).
 
 OSCORE

--- a/draft-ietf-core-dns-over-coap.md
+++ b/draft-ietf-core-dns-over-coap.md
@@ -550,21 +550,26 @@ This is the reason why it is RECOMMENDED to use CoAP Observe {{-coap-observe}} i
 in the DoC domain.
 The DoC server SHOULD provide Observe capabilities on its DoC resource and do as follows.
 
-If the CoAP request indicates that the DoC client wants to observe a resource record, a DoC server
-MAY use a DNS Subscribe message instead of a classic DNS query to fetch the
+A DoC server
+MAY subscribe to DNS push notifications,
+which involves sending a DNS Subscribe message (see ({{Section 6.2 of -dns-push}}),
+instead of a classic DNS query to fetch the
 information on behalf of a DoC client.
-If this is not supported by the DoC server, it MUST act as if the DoC resource were not observable.
+This is particularly useful
+when a CoAP request indicates that the DoC client wants to observe a resource record,
+or when a short-lived record is requested frequently.
+After the list of observers for a particular DNS query has become empty
+(by explicit or implicit cancellation of the observation as per {{Section 3.6 of -coap-observe}}),
+and no other reason to subscribe to that request is present,
+the DoC server SHOULD cancel the corresponding subscription.
+This can involve sending an DNS Unsubscribe message or closing the session (see {{Section 6.4 of -dns-push}}).
 
 Whenever the DoC server receives a DNS Push message from the DNS
 infrastructure for an observed resource record, the DoC server sends an appropriate Observe notification response
 to the DoC client.
 
-If no more DoC clients observe a resource record for which the DoC server has an open subscription,
-the DoC server MUST use a DNS Unsubscribe message to close its subscription to the
-resource record as well.
-
-A DoC server can still provide Observe capabilities to its DoC resource without providing this
-proxying to DNS Push, e.g., if it receives new information on a record through other means.
+A server that cannot proxy to DNS Push (or any other means of obtaining new records) SHOULD NOT send the response as a notification
+(i.e., it should not send the Observe option).
 
 OSCORE
 ------


### PR DESCRIPTION
* Generalize terminology on DNS subscriptions: Talk of the general operations ("subscribe to DNS push notifications", RFC8765 6.4 instead of "send a SUBSCRIBE" message as in 6.4.1, likewise for cancelling a subscription)

  This avoids needlessly going into details about what happens if a concrete message fails, allows closing the entire DSO instead of sending a message, and avoids the need to elaborate on error handling.

  (address [Gorry's points](https://datatracker.ietf.org/doc/draft-ietf-core-dns-over-coap/ballot/#draft-ietf-core-dns-over-coap_gorry-fairhurst) 2 and 2.2)

* Decouple DNS subscriptions from CoAP observations.

  This has been implicit in CoAP (where an intermediary is free to replace repeated GETs/FETCHes with observations and vice versa); the decoupling helps show that the upstream subscription does not have to be cancelled right when the downstream observations end.

  Frequent requests to a short-lived record are given as an alternative example.

  (address [Gorry's points](https://datatracker.ietf.org/doc/draft-ietf-core-dns-over-coap/ballot/#draft-ietf-core-dns-over-coap_gorry-fairhurst) points 2, 2.1 and 2.1')

* Reduce "MUST act as if the DoC resource were not observable" to "SHOULD".

  This is not only due to a contradicting sentence in the old version ("can still provide Observe capabilities"), but also because due to the liberties of intermediaries mentioned above, can not be relied on by the client anyway.

* Rephrase to mention that observations are already maintained as a list on the CoAP server (with entries removed by explicit or implicit cancellation), thus explaining how the DoC server knows that nobody is interested any more.

  (address [Gorry's points](https://datatracker.ietf.org/doc/draft-ietf-core-dns-over-coap/ballot/#draft-ietf-core-dns-over-coap_gorry-fairhurst) point 1)