### PR TITLE
Address Mohamed Boucadair's COMMENT on -17

### DIFF
--- a/draft-ietf-core-dns-over-coap.md
+++ b/draft-ietf-core-dns-over-coap.md
@@ -76,6 +76,10 @@ normative:
   RFC8768: coap-hop-limit
   RFC8949: cbor
   RFC9147: dtls13
+  RFC9460: svcb
+  RFC9461: svcb-dns
+  RFC9462: ddr
+  RFC9463: dnr
   I-D.ietf-core-coap-dtls-alpn: coap-dtls-alpn
 
 informative:
@@ -89,10 +93,6 @@ informative:
   RFC9076: dns-privacy
   RFC9176: core-rd
   RFC9250: doq
-  RFC9460: svcb
-  RFC9461: svcb-dns
-  RFC9462: ddr
-  RFC9463: dnr
   RFC9528: edhoc
   I-D.ietf-core-href: cri
   I-D.ietf-core-transport-indication: transport-indication

--- a/draft-ietf-core-dns-over-coap.md
+++ b/draft-ietf-core-dns-over-coap.md
@@ -238,8 +238,8 @@ For discovery of the DoC resource through a link mechanism that allows describin
 It can be used to identify a generic DNS resolver that is available to the client.
 
 ## Discovery using SVCB Resource Records or DNR
-A DoC server can also be discovered using Service Binding (SVCB) Resource Records (RR) {{-svcb}} {{-svcb-dns}} or Discovery of Network-designated Resolvers (DNR)
-Service Parameters {{-dnr}}.
+A DoC server can also be discovered using Service Binding (SVCB) Resource Records (RR) {{-svcb}} {{-svcb-dns}} resolved via another DNS service (e.g., provided by an unencrypted local resolver) or Discovery of Network-designated Resolvers (DNR)
+Service Parameters {{-dnr}} via DHCP or Router Advertisements.
 {{-coap-tcp}} defines the Application-Layer Protocol Negotiation (ALPN) ID for CoAP over TLS servers and {{-coap-dtls-alpn}} defines the ALPN ID for CoAP over DTLS servers.
 DoC servers that use only OSCORE {{-oscore}} and Ephemeral Diffie-Hellman Over COSE (EDHOC) {{-edhoc}} (with COSE abbreviating "Concise Binary Object Notation (CBOR) Object Signing and Encryption" {{?RFC9052}}) to support security cannot be discovered using these SVCB RR or DNR mechanisms.
 Specifying an alternate discovery mechanism is out of scope of this document.
@@ -300,8 +300,9 @@ The construction algorithm for DoC requests is as follows, going through the pro
 - If the "alpn" SvcParam value for the service is "coap", a CoAP request for CoAP over TLS MUST be constructed.
   If it is "co", a CoAP request for CoAP over DTLS MUST be constructed.
   Any other SvcParamKeys specifying a transport are out of the scope of this document.
-- The destination address for the request SHOULD be taken from additional information about the target, e.g., from an AAAA record associated with the target name or from an "ipv6hint" SvcParam value.
-  As a fallback, an address MAY be queried for the target name of the SVCB record.
+- The destination address for the request SHOULD be taken from additional information about the target.
+  This may include (1) A or AAAA RRs associated with the target name and delivered with the SVCB RR (see {{-ddr}}), (2) "ipv4hint" or "ipv6hint" SvcParams from the SVCB RR (see {{-svcb-dns}}), or (3) from IPv4 or IPv6 addresses provided if DNR {{-dnr}} is used.
+  As a fallback, an address MAY be queried for the target name of the SVCB record from another DNS service.
 - The destination port for the request MUST be taken from the "port" SvcParam value, if present.
   Otherwise, take the default port of the CoAP transport, e.g., with regards to this specification TCP port 5684 for "coap" or UDP port 5684 for "co".
   This document introduces no limitations on the ports that can be used.

--- a/draft-ietf-core-dns-over-coap.md
+++ b/draft-ietf-core-dns-over-coap.md
@@ -231,7 +231,7 @@ Possible options to assure this could be manual configuration of a Uniform Resou
 or automatic configuration, e.g., using a CoRE resource directory
 {{-core-rd}}, DHCP or Router Advertisement options {{-dnr}}, or discovery of designated resolvers
 {{-ddr}}.
-Automatic configuration SHOULD only be done from a trusted source.
+Automatic configuration MUST only be done from a trusted source.
 
 ## Discovery by Resource Type
 For discovery of the DoC resource through a link mechanism that allows describing a resource type

--- a/draft-ietf-core-dns-over-coap.md
+++ b/draft-ietf-core-dns-over-coap.md
@@ -97,7 +97,6 @@ informative:
   I-D.ietf-core-href: cri
   I-D.ietf-core-transport-indication: transport-indication
   I-D.ietf-iotops-7228bis: constr-nodes-bis
-  I-D.lenders-core-dnr: core-dnr
   I-D.amsuess-core-cachable-oscore: cachable-oscore
   DoC-paper: DOI.10.1145/3609423
   I-D.ietf-core-corr-clar: core-corrclar
@@ -242,9 +241,8 @@ It can be used to identify a generic DNS resolver that is available to the clien
 A DoC server can also be discovered using Service Binding (SVCB) Resource Records (RR) {{-svcb}} {{-svcb-dns}} or Discovery of Network-designated Resolvers (DNR)
 Service Parameters {{-dnr}}.
 {{-coap-tcp}} defines the Application-Layer Protocol Negotiation (ALPN) ID for CoAP over TLS servers and {{-coap-dtls-alpn}} defines the ALPN ID for CoAP over DTLS servers.
-Because the ALPN extension is only defined for (D)TLS, these mechanisms cannot be used for DoC servers which use only OSCORE {{-oscore}} and Ephemeral Diffie-Hellman Over COSE (EDHOC) {{-edhoc}} (with COSE abbreviating "Concise Binary Object Notation (CBOR) Object Signing and Encryption" {{?RFC9052}}) for security.
-Specifying an alternate discovery mechanism is out of scope of this specification.
-{{-core-dnr}} provides  further exploration of the challenges here.
+DoC servers that use only OSCORE {{-oscore}} and Ephemeral Diffie-Hellman Over COSE (EDHOC) {{-edhoc}} (with COSE abbreviating "Concise Binary Object Notation (CBOR) Object Signing and Encryption" {{?RFC9052}}) to support security cannot be discovered using these SVCB RR or DNR mechanisms.
+Specifying an alternate discovery mechanism is out of scope of this document.
 
 This document is not an SVCB mapping document for the CoAP schemes
 as defined in {{Section 2.4.3 of -svcb}}.

--- a/draft-ietf-core-dns-over-coap.md
+++ b/draft-ietf-core-dns-over-coap.md
@@ -180,7 +180,7 @@ To avoid the resource requirements of DTLS or TLS on top of UDP (e.g., introduce
 The most important components of DoC can be seen in {{fig-overview-arch}}: a DoC
 client tries to resolve DNS information by sending DNS queries carried within
 CoAP requests to a DoC server.
-That DoC server is a DNS client (i.e., a stub or recursive resolver) that resolves DNS information by using other DNS transports such
+That DoC server can be the authoritive name server for the queried record or a DNS client (i.e., a stub or recursive resolver) that resolves DNS information by using other DNS transports such
 as DNS over UDP {{-dns}}, DNS over HTTPS {{-doh}}, or DNS over QUIC {{-doq}} when communicating with the upstream
 DNS infrastructure.
 Using that information, the DoC server then replies to the queries of the DoC client with DNS

--- a/draft-ietf-core-dns-over-coap.md
+++ b/draft-ietf-core-dns-over-coap.md
@@ -412,7 +412,6 @@ DNS protocol as defined in {{-dns}} is not needed.
 When sending a CoAP request, a DoC client MUST include the DNS query in the body of the CoAP request.
 As specified in {{Section 2.3.1 of -coap-fetch}}, the type of content of the body MUST be indicated using the Content-Format option.
 This document specifies the usage of Content-Format "application/dns-message" (for details, see {{sec:content-format}}).
-A DoC server MUST be able to parse requests of Content-Format "application/dns-message".
 
 ### Support of CoAP Caching {#sec:req-caching}
 

--- a/draft-ietf-core-dns-over-coap.md
+++ b/draft-ietf-core-dns-over-coap.md
@@ -73,6 +73,7 @@ normative:
   RFC8484: doh
   RFC8613: oscore
   RFC8765: dns-push
+  RFC8768: coap-hop-limit
   RFC8949: cbor
   RFC9147: dtls13
   I-D.ietf-core-coap-dtls-alpn: coap-dtls-alpn
@@ -83,6 +84,7 @@ informative:
   RFC3833: dns-threats
   RFC6690: core-link-format
   RFC7228: constr-nodes
+  RFC7858: dot
   RFC8094: dodtls
   RFC9076: dns-privacy
   RFC9176: core-rd
@@ -452,7 +454,7 @@ when it does not send an Accept option.
 Any response Content-Format other than "application/dns-message" MUST be indicated with
 the Content-Format option by the DoC server.
 
-### Response Codes and Handling DNS and CoAP errors
+### Response Codes and Handling DNS and CoAP errors {#sec:resp-codes}
 
 A DNS response indicates either success or failure in the RCODE of the DNS header (see {{-dns}}).
 It is RECOMMENDED that CoAP responses that carry a parseable DNS response use a 2.05 (Content) response code.
@@ -734,6 +736,44 @@ Description: DNS over CoAP resource.
 
 Reference: \[RFC-XXXX\], {{sec:doc-server-selection}}
 
+Operational Considerations
+==========================
+
+## Co-existence of different DNS and CoAP transports
+
+Many DNS transports may co-exist on the DoC server, such as DNS over UDP {{-dns}}, DNS over (D)TLS {{-dot}} {{-dodtls}}, DNS over HTTPS {{-doh}}, or DNS over QUIC {{-doq}}.
+In principle, transports employing channel or object security should be preferred.
+In constrained scenarios, DNS over CoAP is preferable to DNS over DTLS.
+The final decision regarding the preference, however, heavily depends on the use case and is therefore left to the implementers or users and is not defined in this document.
+
+CoAP supports Confirmable and Non-Confirmable messages {{-coap}} to deploy different levels of reliability.
+This document, however, does not enforce any of these message types, as the decision on which one is appropriate depends on the characteristics of the network where DoC is deployed.
+
+## Redirects
+
+Application-layer redirects (e.g., HTTP) redirct a client to a new server.
+In the case of DoC, this leads to a new DNS server.
+This new DNS server may provide different answers to the same DNS query than the previous DNS server.
+At the time of writing, CoAP does not support redirection.
+Future specifications of CoAP redirect may need to consider the impact of different results between previous and new DNS server.
+
+## Proxy Hop-Limit
+
+Mistakes might lead to CoAP proxies forming infinite loops.
+Using the CoAP Hop-Limit option {{-coap-hop-limit}} mitigates such loops.
+
+## Error Handling
+
+{{sec:resp-codes}} specifies that DNS operational errors should be reported back to a DoC client
+using the appropriate DNS RCODE.
+If a DoC client did not receive any successful DNS message from a DoC server for a while, it might
+indicate that the DoC server lost connectivity to the upstream DNS infrastructure.
+The DoC client should handle this error case like a recursive resolver that lost connectivity to the upstream DNS infrastructure.
+In case of CoAP errors, the usual mechanisms for CoAP response codes apply.
+
+## DNS Extensions
+
+DNS extensions that are specific to the choice of transport, such as {{?RFC7828}}, are not applicable to DoC.
 
 --- back
 

--- a/draft-ietf-core-dns-over-coap.md
+++ b/draft-ietf-core-dns-over-coap.md
@@ -165,13 +165,13 @@ To avoid the resource requirements of DTLS or TLS on top of UDP (e.g., introduce
              /
             /
            CoAP request
-+------+   [DNS query]   +------+   DNS query     .---------------.
-| DoC  |---------------->| DoC  |--- --- --- --->|      DNS        |
-|Client|<----------------|Server|<--- --- --- ---| Infrastructure  |
-+------+  CoAP response  +------+  DNS response   '---------------'
++------+   [DNS query]   +------+------+   DNS query     .---------------.
+| DoC  |---------------->| DoC  | DNS  |--- --- --- --->|      DNS        |
+|Client|<----------------|Server|Client|<--- --- --- ---| Infrastructure  |
++------+  CoAP response  +------+------+  DNS response   '---------------'
           [DNS response]
-   \                        /\                                 /
-    '-----DNS over CoAP----'  '--DNS over UDP/HTTPS/QUIC/...--'
+   \                           / \                                     /
+    '------DNS over CoAP------'   '----DNS over UDP/HTTPS/QUIC/...----'
 
 ~~~
 {: #fig-overview-arch title="Basic DoC architecture"}


### PR DESCRIPTION
See https://datatracker.ietf.org/doc/draft-ietf-core-dns-over-coap/ballot/#draft-ietf-core-dns-over-coap_mohamed-boucadair

- “[Add Operational Considerations Section](https://github.com/core-wg/draft-dns-over-coap/pull/52/commits/3f5408291403db549e70ab97ee67d14ce48a7491)“ to address “Lack of operation considerations” and subsections.
- “[Make SVCB references normative](https://github.com/core-wg/draft-dns-over-coap/pull/52/commits/dd4551e2d818c392da20ac859f17b1135463b1cd)” to address “SVCB is normative”
- “[Automatic configuration MUST only be done from a trusted source](https://github.com/core-wg/draft-dns-over-coap/pull/52/commits/a26b13941e879c30912d92f6a6ffd579b36c4764) to address “Trusted source”
- “[Remove contradicting statement and outdated reference about ALPN](https://github.com/core-wg/draft-dns-over-coap/pull/52/commits/efd9eddb1e0a488c1905e322074b283234c6a411)” to address “On OSCORE”
- “[Remove redundant requirement on parsing app/dns-message](https://github.com/core-wg/draft-dns-over-coap/pull/52/commits/b66cadb89cb35ed7bd23581a527b998172a15380)” to address “Redundant requirement?”

All other points raised, I addressed [in the reply to Med's mail](https://mailarchive.ietf.org/arch/msg/core/0XJCP4m1mYEHm-DDzw02Bs0h89c/).