### PR TITLE
Address Gorry Fairhurst's COMMENT on -17

### DIFF
--- a/draft-ietf-core-dns-over-coap.md
+++ b/draft-ietf-core-dns-over-coap.md
@@ -325,7 +325,7 @@ A more generalized construction algorithm for any CoAP request can be found in {
 [^replace-hex]: RFC Ed.: Since the number for "docpath" was not assigned at the time of writing, we
     used the hex `ff 0a` (in decimal 65290; from the private use range of SvcParamKeys) throughout
     this section. Before publication, please replace `ff 0a` with the hexadecimal representation of
-    the final value assigned by IANA in this section.
+    the final value assigned by IANA in this section. Please remove this paragraph after that.
 
 A typical SVCB resource record response for a DoC server at the root path "/" of the server looks
 like the following (the "docpath" SvcParam is the last 4 bytes `ff 0a 00 00` in the binary):

--- a/draft-ietf-core-dns-over-coap.md
+++ b/draft-ietf-core-dns-over-coap.md
@@ -578,8 +578,7 @@ the corresponding implications on message sizes and security properties.
 
 Mapping DoC to DoH
 ------------------
-This document provides no specification on how to map between DoC and DoH, e.g., at a CoAP-to-HTTP-proxy.
-In fact, such a direct mapping is NOT RECOMMENDED:
+This document provides no specification on how to map between DoC and DoH, e.g., at a CoAP-to-HTTP-proxy, such a direct mapping is NOT RECOMMENDED:
 rewriting the FETCH method ({{sec:queries}}) and the TTL rewriting ({{sec:resp-caching}}) as
 specified in this draft would be non-trivial.
 It is RECOMMENDED to use a DNS forwarder to map between DoC and DoH, as would be the case for
@@ -592,7 +591,7 @@ Without secure communication, many possible attacks need to be evaluated in the 
 the application's threat model.
 This includes known threats for unprotected DNS {{-dns-threats}} {{-dns-privacy}} and CoAP {{Section 11 of -coap}}.
 While DoC does not use the random ID of the DNS header (see {{sec:req-caching}}), equivalent protection against off-path poisoning attacks is achieved by using random large token values for unprotected CoAP requests.
-If a DoC message is unprotected it MUST use a random token of at least 2 bytes length to mitigate this kind of poisoning attacks.
+If a DoC message is unprotected it MUST use a random token of at least 2 bytes length to mitigate this kind of poisoning attack.
 
 Implementation Status
 =====================

--- a/draft-ietf-core-dns-over-coap.md
+++ b/draft-ietf-core-dns-over-coap.md
@@ -295,8 +295,8 @@ translation harder, as they require to make space for the longer delimiters, in 
 To use the service binding from an SVCB RR, the DoC client MUST send a DoC request constructed from the SvcParams including "docpath".
 The construction algorithm for DoC requests is as follows, going through the provided records in order of their priority.
 
-- If the "alpn" SvcParam value for the service is "coap", a CoAP request for CoAP over TLS MUST be constructed.
-  If it is "co", a CoAP request for CoAP over DTLS MUST be constructed.
+- If the "alpn" SvcParam value for the service is "coap", a CoAP request for CoAP over TLS MUST be constructed {{-coap-tcp}}.
+  If it is "co", a CoAP request for CoAP over DTLS MUST be constructed {{-coap-dtls-alpn}}.
   Any other SvcParamKeys specifying a transport are out of the scope of this document.
 - The destination address for the request SHOULD be taken from additional information about the target, e.g., from an AAAA record associated with the target name or from an "ipv6hint" SvcParam value.
   As a fallback, an address MAY be queried for the target name of the SVCB record.


### PR DESCRIPTION
See https://datatracker.ietf.org/doc/draft-ietf-core-dns-over-coap/ballot/#draft-ietf-core-dns-over-coap_gorry-fairhurst

- [Add note (in addition to the `RFC Ed.:`) about paragraph removal](https://github.com/core-wg/draft-dns-over-coap/commit/e491bae351040dbdbedffdca8f6a71f05a7d2c4a) to more clearly label that this is a paragraph that the RFC editor should remove (it already starts with `RFC Ed.:`)
- [Add references for "coap" and "co" ALPN to SvcParam algorithm](https://github.com/core-wg/draft-dns-over-coap/commit/a6852861de097a6dd503bc2f503c1e1a494913f5) to address “This seems to be missing a normative reference to: I-D.ietf-core-coap-dtls-alpn.” (I added the reference to [RFC8323](https://datatracker.ietf.org/doc/html/rfc8323) for the "coap" ALPN as a bonus)
- [Address Gorry's nits](https://github.com/core-wg/draft-dns-over-coap/commit/0a52f556c0f480e98097fb97e7df56d1ce29cfa5) to address the nits.