### PR TITLE
Address Paul Wouters's DISCUSS and COMMENT on -17

### DIFF
--- a/draft-ietf-core-dns-over-coap.md
+++ b/draft-ietf-core-dns-over-coap.md
@@ -426,12 +426,12 @@ CoAP body is encoded in the "application/dns-message" Content-Format.
     Content-Format: 553 (application/dns-message)
     Accept: 553 (application/dns-message)
     Payload (binary):
-      00 00 01 20 00 01 00 00 00 00 00 00 07 65 78 61
+      00 00 01 00 00 01 00 00 00 00 00 00 07 65 78 61
       6d 70 6c 65 03 6f 72 67 00 00 1c 00 01
 
     Payload (human-readable):
       ;; ->>Header<<- opcode: QUERY, status: NOERROR, id: 0
-      ;; flags: rd ad; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0
+      ;; flags: rd; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0
 
       ;; QUESTION SECTION:
       ;example.org.             IN      AAAA

--- a/draft-ietf-core-dns-over-coap.md
+++ b/draft-ietf-core-dns-over-coap.md
@@ -244,8 +244,9 @@ Specifying an alternate discovery mechanism is out of scope of this specificatio
 
 This document is not an SVCB mapping document for the CoAP schemes
 as defined in {{Section 2.4.3 of -svcb}}.
-A full SVCB mapping is being prepared in {{-transport-indication}},
-generalizing mechanisms that are introduced in this document for discovery of DoC.
+A full SVCB mapping is specified in {{-transport-indication}}.
+It generalizes mechanisms for all CoAP services.
+This document introduces only the discovery of DoC services.
 
 This document specifies "docpath" as
 a single-valued SvcParamKey that is mandatory for DoC SVCB records.


### PR DESCRIPTION
See https://datatracker.ietf.org/doc/draft-ietf-core-dns-over-coap/ballot/#draft-ietf-core-dns-over-coap_paul-wouters.

- [Remove unnecessary and confusing ad flag from query example](https://github.com/core-wg/draft-dns-over-coap/pull/54/commits/435b76e7096d8afa029dab7c1098004f61000f88) to fix the example mistake pointed out in the DISCUSS
- [Phrase full SVCB mapping sentence more neutrally](https://github.com/core-wg/draft-dns-over-coap/pull/54/commits/bb38fcc9acab91c1c6b0f9592914ecd7ccfda4be) as a more neutral phrasing with regards to SVCB mapping as if the draft were already published.

All other points raised, I will address in the reply to Paul's mail.